### PR TITLE
Check postcode field is defined on current page first

### DIFF
--- a/js/civipostcode_component.js
+++ b/js/civipostcode_component.js
@@ -3,35 +3,37 @@ jQuery(document).ready(function ($) {
   var civiPostCodeFields = Drupal.settings.civiPostCodeFields;
   var sourceUrl = Drupal.settings.baseUrl + "/civicrm/" + civiPostCodeLookupProvider + "/ajax/search?json=1";
   $.each(civiPostCodeFields, function (key, value) {
-    $('[id*="'+value+'"]').autocomplete({
-      source: sourceUrl,
-      minLength: 3,
-      select: function (event, ui) {
-                var id = ui.item.id;
-                var sourceUrl = Drupal.settings.baseUrl + '/civicrm/' + civiPostCodeLookupProvider + '/ajax/get?json=1';
-                var postcodeElementId = value;
-                var result = getCivicrmAndContactSequence(postcodeElementId);
+    if ($('[id*="'+value+'"]').length) { // Check postcode element exists on page first
+      $('[id*="' + value + '"]').autocomplete({
+        source: sourceUrl,
+        minLength: 3,
+        select: function (event, ui) {
+          var id = ui.item.id;
+          var sourceUrl = Drupal.settings.baseUrl + '/civicrm/' + civiPostCodeLookupProvider + '/ajax/get?json=1';
+          var postcodeElementId = value;
+          var result = getCivicrmAndContactSequence(postcodeElementId);
 
-                $.ajax({
-                  dataType: 'json',
-                  data: {id: id},
-                  url: sourceUrl,
-                  success: function (data) {
-                    setAddress(data.address, result.civicrmSeq, result.contactSeq);
-                  }
-                });
-                return false;
-              },
-            //optional (if other layers overlap autocomplete list)
-      open: function (event, ui) {
-              // show scrollbar
-              jQuery(".ui-autocomplete").css({
-                  'overflow-y': 'auto',
-                  'max-height': '200px',
-                  'z-index': '1000',
-              });
+          $.ajax({
+            dataType: 'json',
+            data: {id: id},
+            url: sourceUrl,
+            success: function (data) {
+              setAddress(data.address, result.civicrmSeq, result.contactSeq);
             }
-    });
+          });
+          return false;
+        },
+        //optional (if other layers overlap autocomplete list)
+        open: function (event, ui) {
+          // show scrollbar
+          jQuery(".ui-autocomplete").css({
+            'overflow-y': 'auto',
+            'max-height': '200px',
+            'z-index': '1000',
+          });
+        }
+      });
+    }
   });
 
   // extract civicrm and contact sequence to form id


### PR DESCRIPTION
For multipage webforms, or webforms with contribution pages on, the postcode elements won't always be defined - currently this throws a jquery error in the console.  This patch fixes that by checking if the field exists before trying to assign an autocomplete handler.

This is a single line change despite what the diff might show!  Line 6 is the added line:
`+    if ($('[id*="'+value+'"]').length) { // Check postcode element exists on page first`