### PR TITLE
CGP-1299: Include Required File From webform_civicrm For Adding Civi Postcode Field

### DIFF
--- a/includes/civipostcode_component.inc
+++ b/includes/civipostcode_component.inc
@@ -1,6 +1,7 @@
 <?php
 
-function _webform_edit_civipostcode($component) { 
+function _webform_edit_civipostcode($component) {
+  module_load_include('inc', 'webform_civicrm', 'includes/contact_component');
   $form = array();
   $form['#attached']['js'][] = wf_crm_tokeninput_path();
   return $form;


### PR DESCRIPTION
## Overview
We get an error when trying to add a new 'CiviPostcode' field to webform.

## How it works
1. Create a new webform
2. Create a new field of type to Postcode
3. Error (cannot add field)

## Technical Details
The code for adding the field uses a function wf_crm_tokeninput_path() which is inside webform_civicrm. So for this to work we will need to do
module_load_include('inc', 'webform_civicrm', 'includes/contact_component');
Without this the function will not be visible and throws an error.
How this worked previously (and still works in many cases) is that if the webform has civicrm enabled and has an 'Existing Contact' field then that would have already included the necessary file. So the error will only be thrown on a new webform without this contact field.