### PR TITLE
COMCL-1432: Fix City And Post Code Suffix Fields

### DIFF
--- a/js/civipostcode_component.js
+++ b/js/civipostcode_component.js
@@ -3,8 +3,8 @@ jQuery(document).ready(function ($) {
   var civiPostCodeFields = Drupal.settings.civiPostCodeFields;
   var sourceUrl = Drupal.settings.baseUrl + "/civicrm/" + civiPostCodeLookupProvider + "/ajax/search?json=1";
   $.each(civiPostCodeFields, function (key, value) {
-    if ($('[id*="'+value+'"]').length) { // Check postcode element exists on page first
-      $('[id*="' + value + '"]').autocomplete({
+    if ($('[id*="'+value+'"]').not('[id*="-suffix"]').length) { // Check postcode element exists on page first
+      $('[id*="' + value + '"]').not('[id*="-suffix"]').autocomplete({
         source: sourceUrl,
         minLength: 3,
         select: function (event, ui) {
@@ -68,8 +68,8 @@ jQuery(document).ready(function ($) {
     $('[id *="' + AddstreetAddressElement + '"]').val(address.supplemental_address_1);
     $('[id *="' + AddstreetAddressElement1 + '"]').val(address.supplemental_address_2);
     $('[id *="' + AddstreetAddressElement2 + '"]').val(address.supplemental_address_3);
-    $('[id *="' + cityElement + '"]').val(address.town);
-    $('[id *="' + postalCodeElement + '"]').val(address.postcode);
+    $('[id *="' + cityElement + '"]').val(address.city);
+    $('[id *="' + postalCodeElement + '"]').not('[id*="-suffix"]').val(address.postcode);
     $('[id *="' + countyElement + '"]').val(address.state_province_abbreviation);
   }
 });


### PR DESCRIPTION
## Overview
This PR fixes two issues

1. The city field is auto populated now upon selecting an address which was not happening previously
2. The post code suffix field does not get populated with post code upon selecting an address which was happening previously, due to which the post code was appearing twice on contact view page once as suffix and then as the post code.

## Before
<img width="1792" height="1120" alt="Screenshot 2026-04-21 at 5 31 11 PM" src="https://github.com/user-attachments/assets/b409d4d6-963a-454a-9966-09adc8f27f7e" />

## After
<img width="1792" height="1120" alt="Screenshot 2026-04-21 at 5 31 47 PM" src="https://github.com/user-attachments/assets/2a88357e-d086-466c-846c-1884967a9eab" />

## Technical Details
The previous selector [id*="..."] for post code field wass a "contains" match, so when looking for ...-address-postal-code, it also matched ...-address-postal-code-suffix because the suffix element's ID contained that same substring. 

This Pr fixes this issue by using .not() rather than switching to [id$=...] (ends-with) as it keeps behavior safe for cases where Drupal appends disambiguators like --2 to duplicate IDs, those will still match while the -suffix variant is cleanly excluded.